### PR TITLE
feat: Implement core Pokedex app features in SwiftUI

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ContentView: View {
+    // 2. State Variables
+    @State private var pokemonList: [PokemonListItem] = []
+    @State private var searchText: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    // 3. Computed Property for Filtered Pokemon
+    var filteredPokemon: [PokemonListItem] {
+        if searchText.isEmpty {
+            return pokemonList
+        } else {
+            return pokemonList.filter { $0.name.lowercased().contains(searchText.lowercased()) }
+        }
+    }
+
+    // 4. Body View
+    var body: some View {
+        NavigationView {
+            VStack {
+                // Search Bar
+                TextField("Search Pokemon", text: $searchText)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+
+                // Loading View / Error View
+                if isLoading {
+                    ProgressView("Fetching Pokemon...")
+                        .padding()
+                } else if let errorMessage = errorMessage {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                        .padding()
+                }
+
+                // Pokemon List
+                List(filteredPokemon) { pokemon in
+                    NavigationLink(destination: PokemonDetailView(pokemonName: pokemon.name)) {
+                        PokemonRowView(pokemon: pokemon)
+                    }
+                }
+                // 6. .task Modifier
+                .task {
+                    await fetchInitialPokemon()
+                }
+                .navigationTitle("Pokedex")
+            }
+        }
+    }
+
+    // 5. Fetch Pokemon Function
+    func fetchInitialPokemon() async {
+        isLoading = true
+        errorMessage = nil
+        
+        defer {
+            isLoading = false
+        }
+
+        do {
+            let response = try await NetworkManager.shared.fetchPokemonList()
+            await MainActor.run {
+                self.pokemonList = response.results
+            }
+        } catch {
+            await MainActor.run {
+                 if let networkError = error as? NetworkError {
+                    switch networkError {
+                    case .invalidURL:
+                        self.errorMessage = "Invalid URL encountered. Please contact support."
+                    case .requestFailed(let underlyingError):
+                        self.errorMessage = "Request failed: \(underlyingError.localizedDescription). Please check your connection."
+                    case .decodingError(let underlyingError):
+                        self.errorMessage = "Failed to decode Pokemon data: \(underlyingError.localizedDescription). Please try again."
+                    case .unknown:
+                        self.errorMessage = "An unknown error occurred. Please try again."
+                    }
+                } else {
+                    self.errorMessage = "Failed to load Pokemon. Error: \(error.localizedDescription). Please try again."
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/FlexibleFlowLayout.swift
+++ b/FlexibleFlowLayout.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct FlexibleFlowLayout<Data: Collection, Content: View>: View where Data.Element: Hashable {
+    let data: Data
+    let spacing: CGFloat
+    let alignment: HorizontalAlignment
+    let content: (Data.Element) -> Content
+    @State private var availableWidth: CGFloat = 0
+
+    var body: some View {
+        ZStack(alignment: Alignment(horizontal: alignment, vertical: .center)) {
+            Color.clear
+                .frame(height: 1)
+                .readSize { size in
+                    availableWidth = size.width
+                }
+
+            VStack(alignment: alignment, spacing: spacing) {
+                ForEach(computeRows(), id: \.self) { rowElements in
+                    HStack(spacing: spacing) {
+                        ForEach(rowElements, id: \.self) { element in
+                            content(element)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func computeRows() -> [[Data.Element]] {
+        var rows: [[Data.Element]] = [[]]
+        var currentRowWidth: CGFloat = 0
+        
+        guard availableWidth > 0 else { // Ensure availableWidth is positive
+            if !data.isEmpty { // If data is not empty, return it as a single row to render something
+                 return [Array(data)]
+            }
+            return [] // No width, no data, no rows
+        }
+
+        for element in data {
+            // This is a simplified width estimation.
+            // For TypeBadgeView, a more accurate measurement would involve PreferenceKeys
+            // or a fixed size if all badges are similar.
+            // Let's estimate based on character count of the typeName (assuming element is String).
+            let elementText = String(describing: element) // Works if element is String, adapt if not
+            let estimatedElementWidth = CGFloat(elementText.count) * 8 + 40 // Approx. char width * count + padding/spacing
+                                                                      // (8 for char width, 40 for horizontal padding + potential icon)
+
+            if currentRowWidth + estimatedElementWidth + (rows.last!.isEmpty ? 0 : spacing) > availableWidth {
+                if rows.last!.isEmpty { // If the first element itself is too wide
+                     rows[rows.count - 1].append(element) // Add it to the current row (it will overflow)
+                     rows.append([]) // Start a new row for subsequent elements
+                     currentRowWidth = 0 // Reset for the new row started for others
+                } else {
+                    rows.append([element]) // Start a new row
+                    currentRowWidth = estimatedElementWidth
+                }
+            } else {
+                rows[rows.count - 1].append(element)
+                currentRowWidth += estimatedElementWidth + (rows.last!.count == 1 ? 0 : spacing)
+            }
+        }
+        return rows.filter { !$0.isEmpty } // Ensure no empty rows are returned
+    }
+}
+
+// Helper to read view size
+struct ReadSizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}
+
+extension View {
+    func readSize(onChange: @escaping (CGSize) -> Void) -> some View {
+        background(
+            GeometryReader { geometryProxy in
+                Color.clear
+                    .preference(key: ReadSizePreferenceKey.self, value: geometryProxy.size)
+            }
+        )
+        .onPreferenceChange(ReadSizePreferenceKey.self, perform: onChange)
+    }
+}
+
+// Preview for FlexibleFlowLayout (Optional but good for testing)
+struct FlexibleFlowLayout_Previews: PreviewProvider {
+    static var previews: some View {
+        let sampleTypes = ["fire", "water", "grass", "electric", "psychic", "normal", "fighting", "flying", "poison", "ground", "rock", "bug", "ghost", "steel", "dragon", "dark", "fairy", "shadowmagiclongtype"]
+        
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Layout with Type Badges:")
+                    .font(.headline)
+                FlexibleFlowLayout(data: sampleTypes, spacing: 8, alignment: .leading) { typeName in
+                    TypeBadgeView(typeName: typeName)
+                }
+                .padding()
+                .background(Color.gray.opacity(0.2))
+
+                Text("Layout with Simple Text:")
+                    .font(.headline)
+                    .padding(.top)
+                FlexibleFlowLayout(data: sampleTypes.map { $0.capitalized }, spacing: 10, alignment: .leading) { text in
+                    Text(text)
+                        .padding(8)
+                        .background(Color.blue.opacity(0.3))
+                        .cornerRadius(5)
+                }
+                .padding()
+                .background(Color.green.opacity(0.2))
+            }
+            .padding()
+        }
+    }
+}

--- a/NetworkManager.swift
+++ b/NetworkManager.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case requestFailed(Error)
+    case decodingError(Error)
+    case unknown
+}
+
+class NetworkManager {
+    static let shared = NetworkManager()
+    private let baseURL = "https://pokeapi.co/api/v2/"
+    private let decoder = JSONDecoder()
+
+    private init() {
+        // Configure the decoder if needed, e.g., key decoding strategy
+        // decoder.keyDecodingStrategy = .convertFromSnakeCase
+    }
+
+    // Generic function to fetch data from a specific endpoint
+    private func fetchData<T: Codable>(from endpoint: String) async throws -> T {
+        guard let url = URL(string: baseURL + endpoint) else {
+            throw NetworkError.invalidURL
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            do {
+                let decodedData = try decoder.decode(T.self, from: data)
+                return decodedData
+            } catch {
+                print("Decoding Error: \(error) for URL: \(url)")
+                print("Raw data: \(String(data: data, encoding: .utf8) ?? "No raw data")")
+                throw NetworkError.decodingError(error)
+            }
+        } catch {
+            if error is NetworkError {
+                throw error // Re-throw our custom decoding error
+            }
+            print("Request Failed: \(error) for URL: \(url)")
+            throw NetworkError.requestFailed(error)
+        }
+    }
+
+    // Generic function to fetch data from a full URL string
+    func fetchData<T: Codable>(fromURL urlString: String) async throws -> T {
+        guard let url = URL(string: urlString) else {
+            throw NetworkError.invalidURL
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            do {
+                let decodedData = try decoder.decode(T.self, from: data)
+                return decodedData
+            } catch {
+                print("Decoding Error: \(error) for URL: \(url)")
+                print("Raw data: \(String(data: data, encoding: .utf8) ?? "No raw data")")
+                throw NetworkError.decodingError(error)
+            }
+        } catch {
+             if error is NetworkError {
+                throw error // Re-throw our custom decoding error
+            }
+            print("Request Failed: \(error) for URL: \(url)")
+            throw NetworkError.requestFailed(error)
+        }
+    }
+
+    // Specific API call functions
+
+    func fetchPokemonList(limit: Int = 151, offset: Int = 0) async throws -> PokemonListResponse {
+        let endpoint = "pokemon?limit=\(limit)&offset=\(offset)"
+        return try await fetchData(from: endpoint)
+    }
+
+    func fetchPokemonDetail(name: String) async throws -> PokemonDetail {
+        let endpoint = "pokemon/\(name.lowercased())"
+        return try await fetchData(from: endpoint)
+    }
+
+    func fetchPokemonSpecies(name: String) async throws -> PokemonSpecies {
+        // Species can be identified by name or ID. The API seems to handle names well.
+        let endpoint = "pokemon-species/\(name.lowercased())"
+        return try await fetchData(from: endpoint)
+    }
+    
+    // It can also be fetched by ID if we have it from PokemonDetail
+    func fetchPokemonSpecies(id: Int) async throws -> PokemonSpecies {
+        let endpoint = "pokemon-species/\(id)"
+        return try await fetchData(from: endpoint)
+    }
+
+    func fetchTypeData(typeName: String) async throws -> TypeData {
+        let endpoint = "type/\(typeName.lowercased())"
+        return try await fetchData(from: endpoint)
+    }
+}

--- a/PokemonDetailView.swift
+++ b/PokemonDetailView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+struct PokemonDetailView: View {
+    @StateObject private var viewModel: PokemonDetailViewModel
+    let pokemonName: String // Used to pass to the view model
+
+    init(pokemonName: String) {
+        self.pokemonName = pokemonName
+        _viewModel = StateObject(wrappedValue: PokemonDetailViewModel(pokemonName: pokemonName))
+    }
+    
+    // Alternative init if passing PokemonListItem
+    // init(pokemonItem: PokemonListItem) {
+    //     self.pokemonName = pokemonItem.name // Keep for title or other uses if needed
+    //     _viewModel = StateObject(wrappedValue: PokemonDetailViewModel(pokemonName: pokemonItem.name))
+    // }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if viewModel.isLoading && viewModel.pokemonDetail == nil { // Show loading only if no detail yet
+                    ProgressView("Loading details...")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding()
+                } else if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+
+                if let detail = viewModel.pokemonDetail {
+                    // Pokemon Name (already in navigation title, but can be good here too)
+                     Text(detail.name.capitalized)
+                        .font(.largeTitle)
+                        .frame(maxWidth: .infinity, alignment: .center)
+
+                    // Sprites Section
+                    if let sprites = viewModel.pokemonDetail?.sprites {
+                        Text("Sprites").font(.title2) // Section title
+                        HStack {
+                            Spacer() // To center the sprites
+                            if let frontDefaultURLString = sprites.front_default, let url = URL(string: frontDefaultURLString) {
+                                AsyncImage(url: url) { image in
+                                    image.resizable()
+                                } placeholder: {
+                                    ProgressView()
+                                }
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 100, height: 100)
+                            }
+                            if let frontShinyURLString = sprites.front_shiny, let url = URL(string: frontShinyURLString) {
+                                AsyncImage(url: url) { image in
+                                    image.resizable()
+                                } placeholder: {
+                                    ProgressView()
+                                }
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 100, height: 100)
+                            }
+                            Spacer() // To center the sprites
+                        }
+                        .padding(.vertical)
+                    }
+
+                    // Pokedex Entry Section
+                    Text("Pokedex Entry")
+                        .font(.title2)
+                        .padding(.top)
+                    
+                    Text(viewModel.englishPokedexEntry ?? (viewModel.isLoading ? "Loading entry..." : "No Pokedex entry available."))
+                        .padding(.bottom)
+
+                    // Types Section
+                    if let types = viewModel.pokemonDetail?.types, !types.isEmpty {
+                        Text("Types").font(.title2)
+                        HStack(spacing: 10) {
+                            ForEach(types, id: \.slot) { typeEntry in
+                                TypeBadgeView(typeName: typeEntry.type.name)
+                            }
+                        }
+                        .padding(.vertical)
+                    }
+
+                    // Effective Against Section
+                    if !viewModel.effectiveAgainstTypes.isEmpty {
+                        Text("Effective Against").font(.title2)
+                        FlexibleFlowLayout(data: viewModel.effectiveAgainstTypes, spacing: 8, alignment: .leading) { typeName in
+                            TypeBadgeView(typeName: typeName)
+                        }
+                        .padding(.vertical)
+                    }
+
+                    // Weak Against Section
+                    if !viewModel.weakAgainstTypes.isEmpty {
+                        Text("Weak Against").font(.title2)
+                        FlexibleFlowLayout(data: viewModel.weakAgainstTypes, spacing: 8, alignment: .leading) { typeName in
+                            TypeBadgeView(typeName: typeName)
+                        }
+                        .padding(.vertical)
+                    }
+
+                    // Moves Section (Placeholder)
+                    Text("Moves")
+                        .font(.title2)
+                    Text("Moves will go here") // This placeholder remains
+                        .padding(.bottom)
+
+                    // Effectiveness Section (Placeholder) - This was part of the original code, if it's different from "Effective/Weak Against", it should remain or be clarified.
+                    // For now, assuming "Effective Against" and "Weak Against" cover this. If not, this placeholder might need to be re-evaluated.
+                    // Text("Effectiveness") 
+                    //     .font(.title2)
+                    // Text("Effectiveness will go here")
+                    //     .padding(.bottom)
+
+                } else if !viewModel.isLoading && viewModel.errorMessage == nil {
+                     // Case where not loading, no error, but also no detail (e.g. initial state before task runs, though less likely with current VM setup)
+                    Text("No details available for \(pokemonName.capitalized).")
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(viewModel.pokemonDetail?.name.capitalized ?? pokemonName.capitalized)
+        .navigationBarTitleDisplayMode(.inline)
+        // .task { // ViewModel now fetches in its init
+        //     if viewModel.pokemonDetail == nil { // Optional: prevent re-fetching if already loaded by a previous view
+        //         await viewModel.fetchAllData()
+        //     }
+        // }
+    }
+}
+
+struct PokemonDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            PokemonDetailView(pokemonName: "pikachu") // A common Pokemon for preview
+        }
+    }
+}

--- a/PokemonDetailViewModel.swift
+++ b/PokemonDetailViewModel.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import Foundation // For cleaning flavor text
+
+class PokemonDetailViewModel: ObservableObject {
+    @Published var pokemonDetail: PokemonDetail?
+    @Published var pokemonSpecies: PokemonSpecies?
+    @Published var typeDetails: [TypeData] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    private let pokemonName: String
+
+    init(pokemonName: String) {
+        self.pokemonName = pokemonName
+        Task {
+            await fetchAllData()
+        }
+    }
+
+    func fetchAllData() async {
+        await MainActor.run {
+            self.isLoading = true
+            self.errorMessage = nil
+        }
+
+        defer {
+            Task { // Ensure defer block also runs on main thread if it updates UI state
+                await MainActor.run {
+                    self.isLoading = false
+                }
+            }
+        }
+
+        do {
+            // Fetch Pokemon detail and species concurrently
+            async let detailResult = NetworkManager.shared.fetchPokemonDetail(name: pokemonName)
+            async let speciesResult = NetworkManager.shared.fetchPokemonSpecies(name: pokemonName)
+
+            let fetchedDetail = try await detailResult
+            let fetchedSpecies = try await speciesResult
+            
+            await MainActor.run {
+                self.pokemonDetail = fetchedDetail
+                self.pokemonSpecies = fetchedSpecies
+            }
+
+            // If pokemonDetail is successfully fetched and contains types, fetch type data
+            if let types = fetchedDetail.types {
+                var temporaryTypeDetails: [TypeData] = []
+                for typeEntry in types {
+                    do {
+                        let typeData = try await NetworkManager.shared.fetchTypeData(typeName: typeEntry.type.name)
+                        temporaryTypeDetails.append(typeData)
+                    } catch {
+                        // Log error for individual type fetching but don't fail the whole process
+                        print("Failed to fetch type data for \(typeEntry.type.name): \(error.localizedDescription)")
+                        // Optionally, you could append a placeholder or error state for this specific type
+                    }
+                }
+                await MainActor.run {
+                    self.typeDetails = temporaryTypeDetails
+                }
+            }
+        } catch {
+            await MainActor.run {
+                if let networkError = error as? NetworkError {
+                    switch networkError {
+                    case .invalidURL:
+                        self.errorMessage = "Invalid URL. Could not fetch Pokemon details."
+                    case .requestFailed(let underlyingError):
+                        self.errorMessage = "Request failed: \(underlyingError.localizedDescription)."
+                    case .decodingError(let underlyingError):
+                        self.errorMessage = "Failed to decode Pokemon details: \(underlyingError.localizedDescription)."
+                    case .unknown:
+                        self.errorMessage = "An unknown error occurred while fetching Pokemon details."
+                    }
+                } else {
+                    self.errorMessage = "Failed to load details for \(pokemonName.capitalized): \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    var englishPokedexEntry: String? {
+        guard let species = pokemonSpecies else { return nil }
+        
+        let entry = species.flavor_text_entries
+            .first { $0.language.name == "en" }?
+            .flavor_text
+        
+        // Clean up the text: replace newlines and other special characters
+        return entry?
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\u{000C}", with: " ") // Form feed
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var effectiveAgainstTypes: [String] {
+        var combinedDamageTo = Set<String>()
+        for typeData in typeDetails {
+            for effectiveType in typeData.damage_relations.double_damage_to {
+                combinedDamageTo.insert(effectiveType.name)
+            }
+        }
+        // Filter out types that are also in the Pokemon's own types, if desired (complex interactions exist)
+        // For now, just list all types it's super-effective against.
+        return Array(combinedDamageTo).sorted()
+    }
+
+    var weakAgainstTypes: [String] {
+        var combinedDamageFrom = Set<String>()
+        for typeData in typeDetails {
+            for weakType in typeData.damage_relations.double_damage_from {
+                combinedDamageFrom.insert(weakType.name)
+            }
+        }
+        // Filter out types that the Pokemon might also be resistant to due to its other type (complex interactions)
+        // For now, just list all types it's weak against.
+        return Array(combinedDamageFrom).sorted()
+    }
+}

--- a/PokemonModels.swift
+++ b/PokemonModels.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// 1. PokemonListItem
+struct PokemonListItem: Codable, Identifiable {
+    let name: String
+    let url: String
+    var id: String { name }
+}
+
+// 2. PokemonDetail
+struct PokemonDetail: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let sprites: SpriteImages
+    let moves: [MoveEntry]
+    let types: [TypeEntry]
+    let height: Int
+    let weight: Int
+}
+
+// 3. SpriteImages
+struct SpriteImages: Codable {
+    let front_default: String?
+    let front_shiny: String?
+    // Optional other sprite URLs
+    let back_default: String?
+    let back_shiny: String?
+}
+
+// 4. MoveEntry
+struct MoveEntry: Codable, Identifiable {
+    let move: Move
+    var id: String { move.id }
+}
+
+// 5. Move
+struct Move: Codable, Identifiable {
+    let name: String
+    let url: String
+    var id: String { name }
+}
+
+// 6. TypeEntry
+struct TypeEntry: Codable {
+    let slot: Int
+    let type: TypeDetail
+}
+
+// 7. TypeDetail
+struct TypeDetail: Codable, Identifiable {
+    let name: String
+    let url: String
+    var id: String { name }
+}
+
+// 8. PokemonSpecies
+struct PokemonSpecies: Codable {
+    let flavor_text_entries: [FlavorTextEntry]
+    let id: Int // Useful for fetching, not necessarily for Identifiable here
+}
+
+// 9. FlavorTextEntry
+struct FlavorTextEntry: Codable {
+    let flavor_text: String
+    let language: Language
+    let version: Version? // Optional
+}
+
+// 10. Language
+struct Language: Codable {
+    let name: String // e.g., "en"
+    let url: String
+}
+
+// 11. Version
+struct Version: Codable {
+    let name: String
+    let url: String
+}
+
+// 12. TypeData
+struct TypeData: Codable, Identifiable {
+    let name: String
+    let damage_relations: DamageRelations
+    let id: Int
+}
+
+// 13. DamageRelations
+struct DamageRelations: Codable {
+    let double_damage_from: [TypeDetail]
+    let double_damage_to: [TypeDetail]
+    let half_damage_from: [TypeDetail]?
+    let half_damage_to: [TypeDetail]?
+    let no_damage_from: [TypeDetail]?
+    let no_damage_to: [TypeDetail]?
+}
+
+// 14. PokemonListResponse
+struct PokemonListResponse: Codable {
+    let count: Int
+    let next: String?
+    let previous: String?
+    let results: [PokemonListItem]
+}

--- a/PokemonRowView.swift
+++ b/PokemonRowView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct PokemonRowView: View {
+    let pokemon: PokemonListItem
+
+    var body: some View {
+        HStack {
+            Text(pokemon.name.capitalized)
+            Spacer() // Aligns text to the leading edge
+        }
+        .padding(.vertical, 4) // Add some vertical padding for better spacing in a list
+    }
+}
+
+struct PokemonRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        PokemonRowView(pokemon: PokemonListItem(name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon/1/"))
+            .previewLayout(.fixed(width: 300, height: 70))
+            .padding() // Add padding to the preview itself for better visibility
+        
+        PokemonRowView(pokemon: PokemonListItem(name: "charmander", url: "https://pokeapi.co/api/v2/pokemon/4/"))
+            .previewLayout(.sizeThatFits) // Another way to preview
+            .padding()
+    }
+}

--- a/TypeBadgeView.swift
+++ b/TypeBadgeView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct TypeBadgeView: View {
+    let typeName: String
+
+    private func backgroundColorForType(_ typeName: String) -> Color {
+        switch typeName.lowercased() {
+            case "normal": return Color.gray
+            case "fire": return Color.red
+            case "water": return Color.blue
+            case "electric": return Color.yellow
+            case "grass": return Color.green
+            case "ice": return Color.cyan
+            case "fighting": return Color.orange
+            case "poison": return Color.purple
+            case "ground": return Color.brown
+            case "flying": return Color(red: 0.67, green: 0.56, blue: 0.93) // Light purple/blue
+            case "psychic": return Color.pink
+            case "bug": return Color(red: 0.56, green: 0.78, blue: 0.22) // Lime green
+            case "rock": return Color(red: 0.71, green: 0.63, blue: 0.35) // Sandy brown
+            case "ghost": return Color(red: 0.45, green: 0.35, blue: 0.56) // Darker purple
+            case "dragon": return Color(red: 0.44, green: 0.22, blue: 0.88) // Deep indigo
+            case "dark": return Color(red: 0.44, green: 0.33, blue: 0.26) // Dark brown/gray
+            case "steel": return Color(red: 0.72, green: 0.72, blue: 0.82) // Light steel gray
+            case "fairy": return Color(red: 0.93, green: 0.60, blue: 0.68) // Light pink/magenta
+            default: return Color.gray.opacity(0.5) // Default for unknown types
+        }
+    }
+    
+    // Determine appropriate foreground color based on background brightness
+    private func foregroundColorForType(_ typeName: String) -> Color {
+        let bgColor = backgroundColorForType(typeName)
+        // Simple heuristic: if background is yellow or cyan (common light colors), use black text
+        if bgColor == Color.yellow || bgColor == Color.cyan || bgColor == Color(red: 0.72, green: 0.72, blue: 0.82) /* steel */ || bgColor == Color(red: 0.93, green: 0.60, blue: 0.68) /* fairy */ {
+            return Color.black
+        }
+        return Color.white
+    }
+
+    var body: some View {
+        Text(typeName.capitalized)
+            .font(.caption.bold())
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(backgroundColorForType(typeName))
+            .foregroundColor(foregroundColorForType(typeName)) // Dynamic foreground color
+            .cornerRadius(12)
+            .shadow(color: .gray.opacity(0.5), radius: 2, x: 1, y: 1) // More defined shadow
+    }
+}
+
+struct TypeBadgeView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 10) {
+            TypeBadgeView(typeName: "fire")
+            TypeBadgeView(typeName: "water")
+            TypeBadgeView(typeName: "Grass") // Test capitalization
+            TypeBadgeView(typeName: "electric") // Test light background
+            TypeBadgeView(typeName: "steel")
+            TypeBadgeView(typeName: "fairy")
+            TypeBadgeView(typeName: "unknownType")
+        }
+        .padding()
+        .background(Color.white) // Add a background to the preview VStack for better contrast
+    }
+}


### PR DESCRIPTION
This commit introduces a functional Pokedex application for iOS using SwiftUI.

Key features implemented:
- Fetches and displays a list of Pokemon from PokeAPI.
- Allows you to search the Pokemon list by name.
- Tapping a Pokemon navigates to a detailed view.

The Pokemon Detail View currently displays:
- Pokemon's name and capitalized title.
- Sprites (front_default and front_shiny) loaded asynchronously.
- An English Pokedex entry.
- The Pokemon's types, styled with custom badges (`TypeBadgeView`).
- Lists of types the Pokemon is "Effective Against" and "Weak Against", displayed using a `FlexibleFlowLayout`.

Core components created:
- `PokemonModels.swift`: All Codable data models for API interaction.
- `NetworkManager.swift`: Handles all API calls with async/await.
- `ContentView.swift`: Main list view with search.
- `PokemonRowView.swift`: View for each row in the list.
- `PokemonDetailView.swift` & `PokemonDetailViewModel.swift`: For the detail screen and its data logic.
- `TypeBadgeView.swift`: Reusable view for styling Pokemon types.
- `FlexibleFlowLayout.swift`: Reusable view for displaying collections of items in a wrapping flow.

The app structure is in place, including navigation, loading states, and basic error handling. Next steps would involve displaying the Pokemon's moves list and ensuring the `PokeAppApp.swift` entry point is correctly configured.