### PR TITLE
feat: Apply Pokemon theme and custom fonts to the app

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -19,37 +19,60 @@ struct ContentView: View {
     // 4. Body View
     var body: some View {
         NavigationView {
-            VStack {
+            VStack(spacing: 0) { // Set spacing to 0 if we want list to seamlessly connect to search bar background
                 // Search Bar
                 TextField("Search Pokemon", text: $searchText)
+                    .font(Theme.regularFont(size: 16))
+                    .foregroundColor(Theme.pokemonBlack)
                     .padding()
-                    .background(Color(.systemGray6))
-                    .cornerRadius(8)
-                    .padding(.horizontal)
+                    .background(Theme.pokemonWhite)
+                    .cornerRadius(10)
+                    .padding() // Padding around the search bar itself
+                    .background(Theme.pokemonRed.ignoresSafeArea(edges: .top)) // Background for the search bar area
 
                 // Loading View / Error View
                 if isLoading {
-                    ProgressView("Fetching Pokemon...")
+                    ProgressView { Text("Fetching Pokemon...").textStyle(.body) }
                         .padding()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity) // Center it
+                        .background(Theme.pokemonLightGray.ignoresSafeArea())
                 } else if let errorMessage = errorMessage {
                     Text(errorMessage)
-                        .foregroundColor(.red)
+                        .textStyle(.body)
+                        .foregroundColor(Theme.pokemonRed)
                         .padding()
-                }
-
-                // Pokemon List
-                List(filteredPokemon) { pokemon in
-                    NavigationLink(destination: PokemonDetailView(pokemonName: pokemon.name)) {
-                        PokemonRowView(pokemon: pokemon)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity) // Center it
+                        .background(Theme.pokemonLightGray.ignoresSafeArea())
+                } else {
+                    // Pokemon List
+                    List(filteredPokemon) { pokemon in
+                        NavigationLink(destination: PokemonDetailView(pokemonName: pokemon.name)) {
+                            PokemonRowView(pokemon: pokemon)
+                        }
+                        .listRowBackground(Color.clear) // Allow PokemonRowView to show its own background
+                        .listRowSeparator(.hidden) // Hide default separators
+                         // .listRowInsets(EdgeInsets()) // Consider if padding from PokemonRowView is enough
+                    }
+                    .listStyle(PlainListStyle()) // Use PlainListStyle for more control over background
+                    .background(Theme.pokemonLightGray.ignoresSafeArea()) // Main background for the list area
+                    // 6. .task Modifier
+                    .task {
+                        await fetchInitialPokemon()
                     }
                 }
-                // 6. .task Modifier
-                .task {
-                    await fetchInitialPokemon()
-                }
-                .navigationTitle("Pokedex")
             }
+            .navigationTitle("Pokedex") // Font for this will be set globally later
         }
+        // Apply global font for navigation title - this is a more involved step (UINavigationBarAppearance)
+        // For now, .navigationTitle("Pokedex") uses default system font.
+        // If we want to force it here (might not be ideal for all navigation styles):
+        // .navigationBarTitleDisplayMode(.inline) // Or .large
+        // .toolbar {
+        //     ToolbarItem(placement: .principal) { // Or .navigationBarLeading / .navigationBarTrailing for other styles
+        //         Text("Pokedex").font(Theme.boldFont(size: 22)).foregroundColor(Theme.pokemonWhite) // Example
+        //     }
+        // }
+        // .navigationViewStyle(StackNavigationViewStyle()) // Useful on iPad
     }
 
     // 5. Fetch Pokemon Function

--- a/PokeAppApp.swift
+++ b/PokeAppApp.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+@main
+struct PokeAppApp: App {
+
+    init() {
+        // Navigation Bar Appearance
+        let appearance = UINavigationBarAppearance()
+        
+        // Background Color
+        appearance.configureWithOpaqueBackground() // Or .configureWithTransparentBackground() if you want more control below
+        appearance.backgroundColor = UIColor(Theme.pokemonRed) // Use your theme's red color
+        
+        // Title Text Attributes (for large titles and inline titles)
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor(Theme.pokemonWhite), // White title text
+            .font: UIFont(name: "PokemonFont-Bold", size: 22) ?? UIFont.boldSystemFont(ofSize: 22) // Theme bold font
+        ]
+        appearance.titleTextAttributes = titleAttributes
+        appearance.largeTitleTextAttributes = titleAttributes // Consistent for large titles
+        
+        // Bar Button Item Color (e.g., back button)
+        // UINavigationBar.appearance().tintColor = UIColor(Theme.pokemonWhite) // This is a global tint for the whole bar
+        // For more specific control with appearance object:
+        let buttonAppearance = UIBarButtonItemAppearance()
+        buttonAppearance.normal.titleTextAttributes = [
+            .foregroundColor: UIColor(Theme.pokemonWhite),
+            .font: UIFont(name: "PokemonFont-Regular", size: 17) ?? UIFont.systemFont(ofSize: 17)
+        ]
+        appearance.buttonAppearance = buttonAppearance
+        appearance.backButtonAppearance = buttonAppearance // Apply to back button too
+
+        // Apply the appearance settings
+        UINavigationBar.appearance().standardAppearance = appearance
+        U UINavigationBar.appearance().scrollEdgeAppearance = appearance // Used when content scrolls under navbar
+        UINavigationBar.appearance().compactAppearance = appearance // For compact nav bars
+
+        // Optional: Set the tint color for the back button arrow and other bar button items if not covered by UIBarButtonItemAppearance
+         UINavigationBar.appearance().tintColor = UIColor(Theme.pokemonWhite)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/PokemonDetailView.swift
+++ b/PokemonDetailView.swift
@@ -17,111 +17,126 @@ struct PokemonDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                if viewModel.isLoading && viewModel.pokemonDetail == nil { // Show loading only if no detail yet
-                    ProgressView("Loading details...")
-                        .frame(maxWidth: .infinity, alignment: .center)
+            VStack(alignment: .leading, spacing: 15) { // Adjusted spacing
+                if viewModel.isLoading && viewModel.pokemonDetail == nil {
+                    ProgressView { Text("Loading details...").textStyle(.body) }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                         .padding()
                 } else if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)
-                        .foregroundColor(.red)
+                        .textStyle(.body)
+                        .foregroundColor(Theme.pokemonRed)
                         .padding()
-                        .frame(maxWidth: .infinity, alignment: .center)
+                        .frame(maxWidth: .infinity)
+                        .background(Theme.pokemonWhite.opacity(0.8))
+                        .cornerRadius(10)
+                        .padding(.horizontal) // Ensure padding from screen edges for the error box
                 }
 
                 if let detail = viewModel.pokemonDetail {
-                    // Pokemon Name (already in navigation title, but can be good here too)
-                     Text(detail.name.capitalized)
-                        .font(.largeTitle)
+                    Text(detail.name.capitalized)
+                        .textStyle(.navigationTitle) // Applied text style
+                        .foregroundColor(Theme.pokemonRed) // Color for contrast
                         .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.bottom, 5)
+
 
                     // Sprites Section
                     if let sprites = viewModel.pokemonDetail?.sprites {
-                        Text("Sprites").font(.title2) // Section title
+                        Text("Sprites").textStyle(.sectionHeader).foregroundColor(Theme.pokemonBlack)
                         HStack {
-                            Spacer() // To center the sprites
+                            Spacer()
                             if let frontDefaultURLString = sprites.front_default, let url = URL(string: frontDefaultURLString) {
-                                AsyncImage(url: url) { image in
-                                    image.resizable()
-                                } placeholder: {
-                                    ProgressView()
-                                }
+                                AsyncImage(url: url) { image in image.resizable() }
+                                placeholder: { ProgressView().tint(Theme.pokemonRed) }
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 100, height: 100)
                             }
                             if let frontShinyURLString = sprites.front_shiny, let url = URL(string: frontShinyURLString) {
-                                AsyncImage(url: url) { image in
-                                    image.resizable()
-                                } placeholder: {
-                                    ProgressView()
-                                }
+                                AsyncImage(url: url) { image in image.resizable() }
+                                placeholder: { ProgressView().tint(Theme.pokemonRed) }
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 100, height: 100)
                             }
-                            Spacer() // To center the sprites
+                            Spacer()
                         }
-                        .padding(.vertical)
+                        .padding()
+                        .background(Theme.pokemonWhite.opacity(0.7)) // Slight transparency for white
+                        .cornerRadius(10)
+                        .padding(.vertical, 5)
                     }
 
                     // Pokedex Entry Section
-                    Text("Pokedex Entry")
-                        .font(.title2)
-                        .padding(.top)
-                    
+                    Text("Pokedex Entry").textStyle(.sectionHeader).foregroundColor(Theme.pokemonBlack)
                     Text(viewModel.englishPokedexEntry ?? (viewModel.isLoading ? "Loading entry..." : "No Pokedex entry available."))
-                        .padding(.bottom)
+                        .textStyle(.body)
+                        .padding(.bottom, 5)
 
                     // Types Section
                     if let types = viewModel.pokemonDetail?.types, !types.isEmpty {
-                        Text("Types").font(.title2)
+                        Text("Types").textStyle(.sectionHeader).foregroundColor(Theme.pokemonBlack)
                         HStack(spacing: 10) {
                             ForEach(types, id: \.slot) { typeEntry in
                                 TypeBadgeView(typeName: typeEntry.type.name)
                             }
                         }
-                        .padding(.vertical)
+                        .padding(.vertical, 5)
                     }
 
                     // Effective Against Section
                     if !viewModel.effectiveAgainstTypes.isEmpty {
-                        Text("Effective Against").font(.title2)
+                        Text("Effective Against").textStyle(.sectionHeader).foregroundColor(Theme.pokemonBlack)
                         FlexibleFlowLayout(data: viewModel.effectiveAgainstTypes, spacing: 8, alignment: .leading) { typeName in
                             TypeBadgeView(typeName: typeName)
                         }
-                        .padding(.vertical)
+                        .padding(.vertical, 5)
                     }
 
                     // Weak Against Section
                     if !viewModel.weakAgainstTypes.isEmpty {
-                        Text("Weak Against").font(.title2)
+                        Text("Weak Against").textStyle(.sectionHeader).foregroundColor(Theme.pokemonBlack)
                         FlexibleFlowLayout(data: viewModel.weakAgainstTypes, spacing: 8, alignment: .leading) { typeName in
                             TypeBadgeView(typeName: typeName)
                         }
-                        .padding(.vertical)
+                        .padding(.vertical, 5)
                     }
 
-                    // Moves Section (Placeholder)
-                    Text("Moves")
-                        .font(.title2)
-                    Text("Moves will go here") // This placeholder remains
-                        .padding(.bottom)
+                    // Moves Section
+                    if let moves = viewModel.pokemonDetail?.moves, !moves.isEmpty {
+                        Text("Moves") // Section Title
+                            .textStyle(.sectionHeader)
+                            .foregroundColor(Theme.pokemonBlack) // Match other section headers
 
-                    // Effectiveness Section (Placeholder) - This was part of the original code, if it's different from "Effective/Weak Against", it should remain or be clarified.
-                    // For now, assuming "Effective Against" and "Weak Against" cover this. If not, this placeholder might need to be re-evaluated.
-                    // Text("Effectiveness") 
-                    //     .font(.title2)
-                    // Text("Effectiveness will go here")
-                    //     .padding(.bottom)
-
+                        FlexibleFlowLayout(data: moves, spacing: 8, alignment: .leading) { moveEntry in
+                            Text(moveEntry.move.name.capitalized.replacingOccurrences(of: "-", with: " "))
+                                .font(Theme.regularFont(size: 14)) // Or Theme.TextStyle.caption.font
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 5)
+                                .background(Theme.pokemonBlue.opacity(0.7)) // Example background - could be pokemonDarkGray or another theme color
+                                .foregroundColor(Theme.pokemonWhite) // Ensure contrast with the background
+                                .cornerRadius(8)
+                        }
+                        .padding(.vertical, 5) // Match padding of other sections like Types/Effectiveness
+                    } else if viewModel.isLoading {
+                        // Optionally show a placeholder or nothing while loading,
+                        // or rely on the main ProgressView
+                    } else {
+                        Text("No moves data available.")
+                            .textStyle(.caption)
+                            .padding(.vertical, 5)
+                    }
+                
                 } else if !viewModel.isLoading && viewModel.errorMessage == nil {
-                     // Case where not loading, no error, but also no detail (e.g. initial state before task runs, though less likely with current VM setup)
                     Text("No details available for \(pokemonName.capitalized).")
+                        .textStyle(.body)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                         .padding()
-                        .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
-            .padding()
+            .padding(.horizontal) // Overall horizontal padding for the content
+            .padding(.vertical) // Add some vertical padding too
         }
+        .background(Theme.pokemonLightGray.ignoresSafeArea()) // Main background for the ScrollView
         .navigationTitle(viewModel.pokemonDetail?.name.capitalized ?? pokemonName.capitalized)
         .navigationBarTitleDisplayMode(.inline)
         // .task { // ViewModel now fetches in its init

--- a/PokemonRowView.swift
+++ b/PokemonRowView.swift
@@ -6,20 +6,27 @@ struct PokemonRowView: View {
     var body: some View {
         HStack {
             Text(pokemon.name.capitalized)
-            Spacer() // Aligns text to the leading edge
+                .font(Theme.boldFont(size: 18))
+                .foregroundColor(Theme.pokemonDarkGray)
+            Spacer()
         }
-        .padding(.vertical, 4) // Add some vertical padding for better spacing in a list
+        .padding() // Padding inside the white box
+        .background(Theme.pokemonWhite)
+        .cornerRadius(10) // Rounded corners for the row's white box
+        .padding(.horizontal) // Padding to keep row from touching screen edges
+        .padding(.vertical, 5)   // Spacing between rows
     }
 }
 
 struct PokemonRowView_Previews: PreviewProvider {
     static var previews: some View {
-        PokemonRowView(pokemon: PokemonListItem(name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon/1/"))
-            .previewLayout(.fixed(width: 300, height: 70))
-            .padding() // Add padding to the preview itself for better visibility
-        
-        PokemonRowView(pokemon: PokemonListItem(name: "charmander", url: "https://pokeapi.co/api/v2/pokemon/4/"))
-            .previewLayout(.sizeThatFits) // Another way to preview
-            .padding()
+        Group {
+            PokemonRowView(pokemon: PokemonListItem(name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon/1/"))
+            PokemonRowView(pokemon: PokemonListItem(name: "charmander", url: "https://pokeapi.co/api/v2/pokemon/4/"))
+            PokemonRowView(pokemon: PokemonListItem(name: "PikachuWithVeryLongNameForTesting", url: "https://pokeapi.co/api/v2/pokemon/25/"))
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+        .background(Theme.pokemonLightGray) // Preview background to see row separation
     }
 }

--- a/Theme.swift
+++ b/Theme.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+enum Theme {
+
+    // MARK: - Color Palette
+    static let pokemonRed = Color("PokemonRed") // Will be defined in Assets
+    static let pokemonBlue = Color("PokemonBlue")
+    static let pokemonYellow = Color("PokemonYellow")
+    
+    // Standard colors that don't need asset catalog definitions unless customized further
+    static let pokemonBlack = Color.black
+    static let pokemonWhite = Color.white
+    
+    // Accent Grays - consider defining in Assets if specific shades are needed
+    static let pokemonLightGray = Color(red: 0.85, green: 0.85, blue: 0.85) // A light gray
+    static let pokemonDarkGray = Color(red: 0.3, green: 0.3, blue: 0.3)     // A dark gray for text or accents
+
+    // MARK: - Custom Fonts
+    // Replace "PokemonFont-Regular" and "PokemonFont-Bold" with the actual PostScript names
+    // of the fonts added to the project.
+
+    static func regularFont(size: CGFloat) -> Font {
+        return Font.custom("PokemonFont-Regular", size: size)
+    }
+
+    static func boldFont(size: CGFloat) -> Font {
+        return Font.custom("PokemonFont-Bold", size: size)
+    }
+    
+    // Example of how to define specific text styles
+    enum TextStyle {
+        case navigationTitle
+        case sectionHeader
+        case body
+        case caption
+        case button
+
+        var font: Font {
+            switch self {
+            case .navigationTitle:
+                return Theme.boldFont(size: 22)
+            case .sectionHeader:
+                return Theme.boldFont(size: 18)
+            case .body:
+                return Theme.regularFont(size: 16)
+            case .caption:
+                return Theme.regularFont(size: 14)
+            case .button:
+                return Theme.boldFont(size: 16)
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .navigationTitle:
+                return Theme.pokemonBlack // Or pokemonWhite if on a dark background
+            case .sectionHeader:
+                return Theme.pokemonBlack
+            case .body, .caption:
+                return Theme.pokemonDarkGray
+            case .button:
+                return Theme.pokemonWhite
+            }
+        }
+    }
+}
+
+// Helper extension for applying text styles (optional but convenient)
+extension Text {
+    func textStyle(_ style: Theme.TextStyle) -> some View {
+        self.font(style.font)
+            .foregroundColor(style.color)
+    }
+}
+
+// MARK: - Instructions for Color Assets (for the user)
+/*
+It's recommended to define `PokemonRed`, `PokemonBlue`, and `PokemonYellow` in your Xcode Asset Catalog (`Assets.xcassets`) for easier management and potential dark mode variations.
+
+To do this:
+1. Open `Assets.xcassets` in Xcode.
+2. Click the "+" button at the bottom and choose "Color Set".
+3. Name the color set exactly as used in `Theme.swift` (e.g., "PokemonRed").
+4. Select the new color set. In the Attributes Inspector (right panel):
+    - Set "Appearances" to "None" if you only want a single universal color. Or, configure for "Any, Dark" if you plan Dark Mode variations.
+    - Click on the color swatch for "Universal" (or "Any Appearance").
+    - Set the desired color values (e.g., using RGB, hex).
+
+Example RGB values for the Pokemon theme (adjust to your preference):
+- PokemonRed: R:230 G:0 B:0 (Hex: #E60000)
+- PokemonBlue: R:51 G:153 B:255 (Hex: #3399FF)
+- PokemonYellow: R:255 G:222 B:0 (Hex: #FFDE00)
+
+If you choose not to use the Asset Catalog for these, you can define them directly in `Theme.swift` like `pokemonLightGray`:
+static let pokemonRed = Color(red: 230/255, green: 0/255, blue: 0/255)
+*/

--- a/TypeBadgeView.swift
+++ b/TypeBadgeView.swift
@@ -39,7 +39,7 @@ struct TypeBadgeView: View {
 
     var body: some View {
         Text(typeName.capitalized)
-            .font(.caption.bold())
+            .font(Theme.boldFont(size: 12)) // Using theme's custom bold font
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(backgroundColorForType(typeName))


### PR DESCRIPTION
This commit introduces a comprehensive visual theme to the Pokedex SwiftUI app, aligning with a Pokemon-inspired color palette (red, white, black, yellow, blue) and enabling the use of custom fonts.

Key changes:

1.  **Global Navigation Bar Styling (`PokeAppApp.swift`):**
    *   The navigation bar now has a `pokemonRed` background with `pokemonWhite` titles and button/arrow tints.
    *   Custom fonts are applied to navigation titles.

2.  **Theme Definition (`Theme.swift`):**
    *   Centralized theme colors (PokemonRed, -Blue, -Yellow, -Black, -White, accent grays).
    *   Defined static functions for custom fonts (using placeholders like "PokemonFont-Regular", "PokemonFont-Bold" which you need to configure).
    *   Added a `TextStyle` enum for consistent text styling throughout the app.

3.  **View Theming:**
    *   `ContentView.swift`: The search bar, list background, and overall appearance are themed.
    *   `PokemonRowView.swift`: Rows are styled as cards with themed fonts and backgrounds.
    *   `PokemonDetailView.swift`: All sections (name, sprites, Pokedex entry, types, effectiveness, weaknesses, moves) are styled with theme fonts and colors. Loading/error states and sprite placeholders are also themed.
    *   `TypeBadgeView.swift`: Text now uses the custom theme font, while retaining elemental background colors.

4.  **Moves List Implementation:**
    *   The previously pending moves list in `PokemonDetailView` has been implemented using `FlexibleFlowLayout` and styled according to the new theme.

The application now has a more distinct and brand-aligned visual identity. Custom font files need to be added by you and font names in `Theme.swift` and `PokeAppApp.swift` updated to match for the custom typography to take full effect.