### PR TITLE
Display type icons in TypeView

### DIFF
--- a/JulesPoke/FlexibleFlowLayout.swift
+++ b/JulesPoke/FlexibleFlowLayout.swift
@@ -40,7 +40,7 @@ struct FlexibleFlowLayout<Data: Collection, Content: View>: View where Data.Elem
 
         for element in data {
             // This is a simplified width estimation.
-            // For TypeBadgeView, a more accurate measurement would involve PreferenceKeys
+            // For views like TypeView, a more accurate measurement would involve PreferenceKeys
             // or a fixed size if all badges are similar.
             // Let's estimate based on character count of the typeName (assuming element is String).
             let elementText = String(describing: element) // Works if element is String, adapt if not
@@ -95,7 +95,7 @@ struct FlexibleFlowLayout_Previews: PreviewProvider {
                 Text("Layout with Type Badges:")
                     .font(.headline)
                 FlexibleFlowLayout(data: sampleTypes, spacing: 8, alignment: .leading) { typeName in
-                    TypeBadgeView(typeName: typeName)
+                    TypeView(typeName: typeName)
                 }
                 .padding()
                 .background(Color.gray.opacity(0.2))

--- a/JulesPoke/PokemonDetailView.swift
+++ b/JulesPoke/PokemonDetailView.swift
@@ -89,7 +89,7 @@ struct PokemonDetailView: View {
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         HStack(spacing: 10) {
                             ForEach(types, id: \.slot) { typeEntry in
-                                TypeBadgeView(typeName: typeEntry.type.name)
+                                TypeView(typeName: typeEntry.type.name)
                             }
                         }
                         .padding(.vertical)
@@ -101,7 +101,7 @@ struct PokemonDetailView: View {
                             .font(Font.custom("Onest", size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         FlexibleFlowLayout(data: viewModel.effectiveAgainstTypes, spacing: 8, alignment: .leading) { typeName in
-                            TypeBadgeView(typeName: typeName)
+                            TypeView(typeName: typeName)
                         }
                         .padding(.vertical)
                     }
@@ -112,7 +112,7 @@ struct PokemonDetailView: View {
                             .font(Font.custom("Onest", size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         FlexibleFlowLayout(data: viewModel.weakAgainstTypes, spacing: 8, alignment: .leading) { typeName in
-                            TypeBadgeView(typeName: typeName)
+                            TypeView(typeName: typeName)
                         }
                         .padding(.vertical)
                     }

--- a/JulesPoke/TypeView.swift
+++ b/JulesPoke/TypeView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Displays a Pokémon type with its corresponding icon from the asset catalog.
+struct TypeView: View {
+    let typeName: String
+
+    /// Returns the image asset name for a given type.
+    private func iconName(for type: String) -> String {
+        "\(type.lowercased())_type_symbol"
+    }
+
+    /// Background color used for the badge, matching TypeBadgeView's logic.
+    private func backgroundColorForType(_ typeName: String) -> Color {
+        switch typeName.lowercased() {
+            case "fire": return Color("PokemonRed")
+            case "water": return Color("PokemonBlue")
+            case "electric": return Color("PokemonYellow")
+            case "normal": return Color("PokemonBlack")
+            case "grass", "bug": return Color("PokemonYellow")
+            case "ice", "flying", "fairy", "steel": return Color("PokemonBlue")
+            case "fighting", "poison", "ground", "psychic", "rock", "ghost", "dragon", "dark":
+                return Color("PokemonBlack")
+            default: return Color("PokemonBlack").opacity(0.7)
+        }
+    }
+
+    /// Determines an appropriate foreground color based on the background.
+    private func foregroundColorForType(_ typeName: String) -> Color {
+        let bgColor = backgroundColorForType(typeName)
+        if bgColor == Color("PokemonRed") ||
+            bgColor == Color("PokemonBlue") ||
+            bgColor == Color("PokemonBlack") ||
+            bgColor == Color("PokemonBlack").opacity(0.7) {
+            return Color("PokemonWhite")
+        } else if bgColor == Color("PokemonYellow") || bgColor == Color("PokemonWhite") {
+            return Color("PokemonBlack")
+        }
+        return Color("PokemonBlack")
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(iconName(for: typeName))
+                .resizable()
+                .frame(width: 16, height: 16)
+            Text(typeName.capitalized)
+                .font(Font.custom("Onest", size: 12).weight(.bold))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(backgroundColorForType(typeName))
+        .foregroundColor(foregroundColorForType(typeName))
+        .cornerRadius(12)
+        .shadow(color: .gray.opacity(0.5), radius: 2, x: 1, y: 1)
+    }
+}
+
+struct TypeView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 10) {
+            TypeView(typeName: "fire")
+            TypeView(typeName: "water")
+            TypeView(typeName: "grass")
+            TypeView(typeName: "electric")
+        }
+        .padding()
+        .background(Color.white)
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `TypeView` that displays the type icon and name
- swap `TypeBadgeView` usages for `TypeView`
- update flow layout comments and preview for the new view

## Testing
- `swift --version`
- `swift test -c release` *(fails: Could not find Package.swift)*