### PR TITLE
Apply custom font Playpen Sans

### DIFF
--- a/JulesPoke/ContentView.swift
+++ b/JulesPoke/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
         appearance.backgroundColor = UIColor(Color("PokemonRed")) // Set background color
         
         // Set title font
-        let titleFont = UIFont(name: "Onest", size: 22) ?? UIFont.systemFont(ofSize: 22, weight: .bold)
+        let titleFont = UIFont.playpenSans(ofSize: 22, weight: .bold)
         appearance.titleTextAttributes = [
             .foregroundColor: UIColor(Color("PokemonWhite")),
             .font: titleFont
@@ -44,7 +44,7 @@ struct ContentView: View {
             VStack {
                 // Search Bar
                 TextField("Search Pokemon", text: $searchText)
-                    .font(Font.custom("Onest", size: 17)) // Apply custom font to TextField
+                    .font(.playpenSans(size: 17)) // Apply custom font to TextField
                     .foregroundColor(Color("PokemonBlack")) // Text color for TextField
                     .padding()
                     .background(Color("PokemonWhite")) // Background for TextField
@@ -59,13 +59,13 @@ struct ContentView: View {
                 if isLoading {
                     ProgressView { // Custom label for ProgressView
                         Text("Fetching Pokemon...")
-                            .font(Font.custom("Onest", size: 17)) // Apply custom font
+                            .font(.playpenSans(size: 17)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack"))
                     }
                     .padding()
                 } else if let errorMessage = errorMessage {
                     Text(errorMessage)
-                        .font(Font.custom("Onest", size: 17)) // Apply custom font
+                        .font(.playpenSans(size: 17)) // Apply custom font
                         .foregroundColor(Color("PokemonRed")) // Error text color
                         .padding()
                 }

--- a/JulesPoke/Font+PlaypenSans.swift
+++ b/JulesPoke/Font+PlaypenSans.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Font {
+    /// Convenience helper for the Playpen Sans font
+    static func playpenSans(size: CGFloat) -> Font {
+        .custom("Playpen Sans", size: size)
+    }
+}
+
+extension UIFont {
+    /// Convenience helper for the Playpen Sans font
+    static func playpenSans(ofSize size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        UIFont(name: "Playpen Sans", size: size) ?? .systemFont(ofSize: size, weight: weight)
+    }
+}

--- a/JulesPoke/Fonts/Onest-VariableFont_wght.ttf
+++ b/JulesPoke/Fonts/Onest-VariableFont_wght.ttf
@@ -1,1 +1,0 @@
-This is a placeholder for the Onest-VariableFont_wght.ttf font file.

--- a/JulesPoke/Fonts/PlaypenSans-VariableFont_wght.ttf
+++ b/JulesPoke/Fonts/PlaypenSans-VariableFont_wght.ttf
@@ -1,0 +1,1 @@
+This is a placeholder for the PlaypenSans-VariableFont_wght.ttf font file.

--- a/JulesPoke/Info.plist
+++ b/JulesPoke/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>UIAppFonts</key>
 	<array>
-		<string>Onest-VariableFont_wght.ttf</string>
+               <string>Fonts/PlaypenSans-VariableFont_wght.ttf</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/JulesPoke/PokemonDetailView.swift
+++ b/JulesPoke/PokemonDetailView.swift
@@ -21,14 +21,14 @@ struct PokemonDetailView: View {
                 if viewModel.isLoading && viewModel.pokemonDetail == nil { // Show loading only if no detail yet
                     ProgressView { // Custom label for ProgressView
                         Text("Loading details...")
-                            .font(Font.custom("Onest", size: 17)) // Apply custom font
+                            .font(.playpenSans(size: 17)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack"))
                     }
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding()
                 } else if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)
-                        .font(Font.custom("Onest", size: 17)) // Apply custom font
+                        .font(.playpenSans(size: 17)) // Apply custom font
                         .foregroundColor(Color("PokemonRed")) // Error text color
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -37,14 +37,14 @@ struct PokemonDetailView: View {
                 if let detail = viewModel.pokemonDetail {
                     // Pokemon Name (already in navigation title, but can be good here too)
                      Text(detail.name.capitalized)
-                        .font(Font.custom("Onest", size: 34)) // Apply custom font
+                        .font(.playpenSans(size: 34)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Text color
                         .frame(maxWidth: .infinity, alignment: .center)
 
                     // Sprites Section
                     if let sprites = viewModel.pokemonDetail?.sprites {
                         Text("Sprites")
-                            .font(Font.custom("Onest", size: 22)) // Apply custom font
+                            .font(.playpenSans(size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         HStack {
                             Spacer() // To center the sprites
@@ -73,19 +73,19 @@ struct PokemonDetailView: View {
 
                     // Pokedex Entry Section
                     Text("Pokedex Entry")
-                        .font(Font.custom("Onest", size: 22)) // Apply custom font
+                        .font(.playpenSans(size: 22)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Section title color
                         .padding(.top)
                     
                     Text(viewModel.englishPokedexEntry ?? (viewModel.isLoading ? "Loading entry..." : "No Pokedex entry available."))
-                        .font(Font.custom("Onest", size: 17)) // Apply custom font
+                        .font(.playpenSans(size: 17)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Text color
                         .padding(.bottom)
 
                     // Types Section
                     if let types = viewModel.pokemonDetail?.types, !types.isEmpty {
                         Text("Types")
-                            .font(Font.custom("Onest", size: 22)) // Apply custom font
+                            .font(.playpenSans(size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         HStack(spacing: 10) {
                             ForEach(types, id: \.slot) { typeEntry in
@@ -98,7 +98,7 @@ struct PokemonDetailView: View {
                     // Effective Against Section
                     if !viewModel.effectiveAgainstTypes.isEmpty {
                         Text("Effective Against")
-                            .font(Font.custom("Onest", size: 22)) // Apply custom font
+                            .font(.playpenSans(size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         FlexibleFlowLayout(data: viewModel.effectiveAgainstTypes, spacing: 8, alignment: .leading) { typeName in
                             TypeBadgeView(typeName: typeName)
@@ -109,7 +109,7 @@ struct PokemonDetailView: View {
                     // Weak Against Section
                     if !viewModel.weakAgainstTypes.isEmpty {
                         Text("Weak Against")
-                            .font(Font.custom("Onest", size: 22)) // Apply custom font
+                            .font(.playpenSans(size: 22)) // Apply custom font
                             .foregroundColor(Color("PokemonBlack")) // Section title color
                         FlexibleFlowLayout(data: viewModel.weakAgainstTypes, spacing: 8, alignment: .leading) { typeName in
                             TypeBadgeView(typeName: typeName)
@@ -119,10 +119,10 @@ struct PokemonDetailView: View {
 
                     // Moves Section (Placeholder)
                     Text("Moves")
-                        .font(Font.custom("Onest", size: 22)) // Apply custom font
+                        .font(.playpenSans(size: 22)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Section title color
                     Text("Moves will go here") // This placeholder remains
-                        .font(Font.custom("Onest", size: 17)) // Apply custom font
+                        .font(.playpenSans(size: 17)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Text color
                         .padding(.bottom)
 
@@ -136,7 +136,7 @@ struct PokemonDetailView: View {
                 } else if !viewModel.isLoading && viewModel.errorMessage == nil {
                      // Case where not loading, no error, but also no detail (e.g. initial state before task runs, though less likely with current VM setup)
                     Text("No details available for \(pokemonName.capitalized).")
-                        .font(Font.custom("Onest", size: 17)) // Apply custom font
+                        .font(.playpenSans(size: 17)) // Apply custom font
                         .foregroundColor(Color("PokemonBlack")) // Text color
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .center)

--- a/JulesPoke/PokemonRowView.swift
+++ b/JulesPoke/PokemonRowView.swift
@@ -6,7 +6,7 @@ struct PokemonRowView: View {
     var body: some View {
         HStack {
             Text(pokemon.name.capitalized)
-                .font(Font.custom("Onest", size: 17)) // Apply custom font
+                .font(.playpenSans(size: 17)) // Apply custom font
                 .foregroundColor(Color("PokemonBlack")) // Set text color
             Spacer() // Aligns text to the leading edge
         }

--- a/JulesPoke/TypeBadgeView.swift
+++ b/JulesPoke/TypeBadgeView.swift
@@ -31,7 +31,7 @@ struct TypeBadgeView: View {
 
     var body: some View {
         Text(typeName.capitalized)
-            .font(Font.custom("Onest", size: 12).weight(.bold)) // Apply custom font
+            .font(Font.playpenSans(size: 12).weight(.bold)) // Apply custom font
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(backgroundColorForType(typeName))

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # jules_ios_test
+
+This project demonstrates using a custom variable font named **Playpen Sans**. The font file is located under `JulesPoke/Fonts/` and is loaded via the `UIAppFonts` entry in `Info.plist`. You can use the helper methods `Font.playpenSans(size:)` and `UIFont.playpenSans(ofSize:weight:)` to apply this font across the app.
+


### PR DESCRIPTION
## Summary
- rename placeholder font to `PlaypenSans-VariableFont_wght.ttf`
- add new `Font.playpenSans`/`UIFont.playpenSans` helpers
- register the new font in Info.plist
- update all views to use the Playpen Sans helpers
- update README about Playpen Sans

## Testing
- `swift test` *(fails: Could not find Package.swift)*
