### PR TITLE
Fix: Ensure app uses full screen and background extends to edges.

### DIFF
--- a/JulesPoke/ContentView.swift
+++ b/JulesPoke/ContentView.swift
@@ -79,6 +79,7 @@ struct ContentView: View {
             }
             .background(Color("PokemonWhite")) // Background for the VStack
         }
+        .ignoresSafeArea()
     }
 
     // 5. Fetch Pokemon Function


### PR DESCRIPTION
Modified ContentView.swift by applying .ignoresSafeArea() to the NavigationView. This allows the background color to fill the entire screen, resolving the issue of black bars appearing on some devices. Content within the view remains respectful of safe area layout guides.