### PR TITLE
Show move types in detail view

### DIFF
--- a/JulesPoke/NetworkManager.swift
+++ b/JulesPoke/NetworkManager.swift
@@ -99,4 +99,9 @@ class NetworkManager {
         let endpoint = "type/\(typeName.lowercased())"
         return try await fetchData(from: endpoint)
     }
+
+    func fetchMoveDetail(moveName: String) async throws -> MoveDetailData {
+        let endpoint = "move/\(moveName.lowercased())"
+        return try await fetchData(from: endpoint)
+    }
 }

--- a/JulesPoke/PokemonDetailView.swift
+++ b/JulesPoke/PokemonDetailView.swift
@@ -100,11 +100,21 @@ struct PokemonDetailView: View {
                         .padding(.vertical)
                     }
 
-                    // Moves Section (Placeholder)
-                    Text("Moves")
-                        .font(.title2)
-                    Text("Moves will go here") // This placeholder remains
+                    // Moves Section
+                    if !viewModel.moveDetails.isEmpty {
+                        Text("Moves")
+                            .font(.title2)
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(viewModel.moveDetails) { move in
+                                HStack(spacing: 8) {
+                                    TypeBadgeView(typeName: move.type.name)
+                                    Text(move.name.capitalized)
+                                        .foregroundColor(.primary)
+                                }
+                            }
+                        }
                         .padding(.bottom)
+                    }
 
                     // Effectiveness Section (Placeholder) - This was part of the original code, if it's different from "Effective/Weak Against", it should remain or be clarified.
                     // For now, assuming "Effective Against" and "Weak Against" cover this. If not, this placeholder might need to be re-evaluated.

--- a/JulesPoke/PokemonModels.swift
+++ b/JulesPoke/PokemonModels.swift
@@ -40,6 +40,14 @@ struct Move: Codable, Identifiable {
     var id: String { name }
 }
 
+// Details for an individual move used to display additional
+// information such as the move's type.
+struct MoveDetailData: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let type: TypeDetail
+}
+
 // 6. TypeEntry
 struct TypeEntry: Codable {
     let slot: Int


### PR DESCRIPTION
## Summary
- add MoveDetailData model
- add fetchMoveDetail to network layer
- load move details in PokemonDetailViewModel
- show moves in PokemonDetailView with type badges

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*