### PR TITLE
Add evolution chain section

### DIFF
--- a/JulesPoke/NetworkManager.swift
+++ b/JulesPoke/NetworkManager.swift
@@ -99,4 +99,8 @@ class NetworkManager {
         let endpoint = "type/\(typeName.lowercased())"
         return try await fetchData(from: endpoint)
     }
+
+    func fetchEvolutionChain(urlString: String) async throws -> EvolutionChain {
+        return try await fetchData(fromURL: urlString)
+    }
 }

--- a/JulesPoke/PokemonDetailView.swift
+++ b/JulesPoke/PokemonDetailView.swift
@@ -100,6 +100,20 @@ struct PokemonDetailView: View {
                         .padding(.vertical)
                     }
 
+                    // Evolution Chain Section
+                    if viewModel.evolutionNames.count > 1 {
+                        Text("Evolution Chain").font(.title2)
+                        HStack(spacing: 4) {
+                            ForEach(viewModel.evolutionNames.indices, id: \.\.self) { index in
+                                Text(viewModel.evolutionNames[index].capitalized)
+                                if index < viewModel.evolutionNames.count - 1 {
+                                    Image(systemName: "arrow.right")
+                                }
+                            }
+                        }
+                        .padding(.vertical)
+                    }
+
                     // Moves Section (Placeholder)
                     Text("Moves")
                         .font(.title2)

--- a/JulesPoke/PokemonModels.swift
+++ b/JulesPoke/PokemonModels.swift
@@ -57,6 +57,7 @@ struct TypeDetail: Codable, Identifiable {
 struct PokemonSpecies: Codable {
     let flavor_text_entries: [FlavorTextEntry]
     let id: Int // Useful for fetching, not necessarily for Identifiable here
+    let evolution_chain: EvolutionChainInfo
 }
 
 // 9. FlavorTextEntry
@@ -101,4 +102,27 @@ struct PokemonListResponse: Codable {
     let next: String?
     let previous: String?
     let results: [PokemonListItem]
+}
+
+// 15. EvolutionChainInfo
+struct EvolutionChainInfo: Codable {
+    let url: String
+}
+
+// 16. EvolutionChain
+struct EvolutionChain: Codable {
+    let id: Int
+    let chain: EvolutionChainLink
+}
+
+// 17. EvolutionChainLink
+struct EvolutionChainLink: Codable {
+    let species: SpeciesSummary
+    let evolves_to: [EvolutionChainLink]
+}
+
+// 18. SpeciesSummary
+struct SpeciesSummary: Codable {
+    let name: String
+    let url: String
 }


### PR DESCRIPTION
## Summary
- include new Pokemon evolution chain models
- get evolution chain from the API in `NetworkManager`
- load evolution chain in `PokemonDetailViewModel`
- display evolution chain on the detail page

## Testing
- `swift test` *(fails: Could not find Package.swift)*