### PR TITLE
Add horizontal sprite scroller

### DIFF
--- a/JulesPoke/PokemonDetailView.swift
+++ b/JulesPoke/PokemonDetailView.swift
@@ -37,30 +37,27 @@ struct PokemonDetailView: View {
 
                     // Sprites Section
                     if let sprites = viewModel.pokemonDetail?.sprites {
-                        Text("Sprites").font(.title2) // Section title
-                        HStack {
-                            Spacer() // To center the sprites
-                            if let frontDefaultURLString = sprites.front_default, let url = URL(string: frontDefaultURLString) {
-                                AsyncImage(url: url) { image in
-                                    image.resizable()
-                                } placeholder: {
-                                    ProgressView()
+                        let spriteURLs = sprites.allSpriteURLs
+                        if !spriteURLs.isEmpty {
+                            Text("Sprites").font(.title2)
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 16) {
+                                    ForEach(spriteURLs, id: \.self) { urlString in
+                                        if let url = URL(string: urlString) {
+                                            AsyncImage(url: url) { image in
+                                                image.resizable()
+                                            } placeholder: {
+                                                ProgressView()
+                                            }
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 100, height: 100)
+                                        }
+                                    }
                                 }
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 100, height: 100)
+                                .padding(.horizontal)
                             }
-                            if let frontShinyURLString = sprites.front_shiny, let url = URL(string: frontShinyURLString) {
-                                AsyncImage(url: url) { image in
-                                    image.resizable()
-                                } placeholder: {
-                                    ProgressView()
-                                }
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 100, height: 100)
-                            }
-                            Spacer() // To center the sprites
+                            .padding(.vertical)
                         }
-                        .padding(.vertical)
                     }
 
                     // Pokedex Entry Section

--- a/JulesPoke/PokemonModels.swift
+++ b/JulesPoke/PokemonModels.swift
@@ -19,12 +19,80 @@ struct PokemonDetail: Codable, Identifiable {
 }
 
 // 3. SpriteImages
+/// Represents all sprite variations returned by the PokeAPI for a Pokémon.
+/// Only a subset is modelled here but ``allSpriteURLs`` will expose every
+/// non-nil URL so new fields won't require changes in the view layer.
 struct SpriteImages: Codable {
     let front_default: String?
     let front_shiny: String?
-    // Optional other sprite URLs
+    let front_female: String?
+    let front_shiny_female: String?
     let back_default: String?
     let back_shiny: String?
+    let back_female: String?
+    let back_shiny_female: String?
+    let other: OtherSprites?
+
+    /// Collects every available sprite URL into a flat array.
+    var allSpriteURLs: [String] {
+        var urls: [String] = []
+
+        func appendIfPresent(_ value: String?) {
+            if let value = value { urls.append(value) }
+        }
+
+        appendIfPresent(front_default)
+        appendIfPresent(front_shiny)
+        appendIfPresent(front_female)
+        appendIfPresent(front_shiny_female)
+        appendIfPresent(back_default)
+        appendIfPresent(back_shiny)
+        appendIfPresent(back_female)
+        appendIfPresent(back_shiny_female)
+
+        if let other = other {
+            appendIfPresent(other.dream_world?.front_default)
+            appendIfPresent(other.dream_world?.front_female)
+            appendIfPresent(other.home?.front_default)
+            appendIfPresent(other.home?.front_female)
+            appendIfPresent(other.home?.front_shiny)
+            appendIfPresent(other.home?.front_shiny_female)
+            appendIfPresent(other.officialArtwork?.front_default)
+            appendIfPresent(other.officialArtwork?.front_shiny)
+        }
+
+        return urls
+    }
+}
+
+/// Container for sprites found in the `other` section of the API.
+struct OtherSprites: Codable {
+    let dream_world: DreamWorldSprites?
+    let home: HomeSprites?
+    let officialArtwork: OfficialArtworkSprites?
+
+    enum CodingKeys: String, CodingKey {
+        case dream_world
+        case home
+        case officialArtwork = "official-artwork"
+    }
+}
+
+struct DreamWorldSprites: Codable {
+    let front_default: String?
+    let front_female: String?
+}
+
+struct HomeSprites: Codable {
+    let front_default: String?
+    let front_female: String?
+    let front_shiny: String?
+    let front_shiny_female: String?
+}
+
+struct OfficialArtworkSprites: Codable {
+    let front_default: String?
+    let front_shiny: String?
 }
 
 // 4. MoveEntry


### PR DESCRIPTION
## Summary
- parse additional sprite fields from the API
- collect all sprite URLs in `SpriteImages.allSpriteURLs`
- display sprites horizontally in `PokemonDetailView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*